### PR TITLE
Update cluster running example from docs

### DIFF
--- a/environment-usages/kubernetes-cluster-running/index.json
+++ b/environment-usages/kubernetes-cluster-running/index.json
@@ -2,8 +2,7 @@
   "title": "Kubernetes",
   "description": "Multi node Kubernetes cluster configured using Kubeadm",
   "details": {
-    "steps": [
-      {
+    "steps": [{
         "title": "Step 1",
         "text": "step1.md"
       },
@@ -21,6 +20,6 @@
     "uilayout": "terminal-terminal"
   },
   "backend": {
-    "imageid": "kubernetes-cluster:1.18"
+    "imageid": "kubernetes-cluster-running:1.18"
   }
 }

--- a/environment-usages/kubernetes-cluster-running/index.json
+++ b/environment-usages/kubernetes-cluster-running/index.json
@@ -2,7 +2,8 @@
   "title": "Kubernetes",
   "description": "Multi node Kubernetes cluster configured using Kubeadm",
   "details": {
-    "steps": [{
+    "steps": [
+      {
         "title": "Step 1",
         "text": "step1.md"
       },

--- a/environment-usages/kubernetes-cluster-running/step1.md
+++ b/environment-usages/kubernetes-cluster-running/step1.md
@@ -1,5 +1,5 @@
-If you need a cluster available, 
+If you need a cluster available,
 
-The Kubernetes nodes are not configured. If you want to configure the nodes then you'd need to run `kubeadm` which has been set and configured. For example, for following command will initialise the master with the latest version installed.
+The Kubernetes nodes are configured and running. If you want to configure the nodes then you'd need to run `kubeadm` which has been set and configured. For example, for following command will initialise the master with the latest version installed.
 
 `kubeadm init --kubernetes-version $(kubeadm version -o short)`{{execute HOST1}}

--- a/environment-usages/kubernetes-cluster/index.json
+++ b/environment-usages/kubernetes-cluster/index.json
@@ -2,8 +2,7 @@
   "title": "Kubernetes",
   "description": "Multi node Kubernetes cluster configured using Kubeadm",
   "details": {
-    "steps": [
-      {
+    "steps": [{
         "title": "Step 1",
         "text": "step1.md"
       },
@@ -21,6 +20,6 @@
     "uilayout": "terminal-terminal"
   },
   "backend": {
-    "imageid": "kubernetes-cluster-running:1.18"
+    "imageid": "kubernetes-cluster:1.18"
   }
 }


### PR DESCRIPTION
The documentation for a running Kubernetes 1.18 cluster does not have the correct image tag for the code example (via https://www.katacoda.community/environments.html) 

This code updates the instructions and uses the correct tag for the Katacoda example.