### PR TITLE
Fix 404 during bsdtar install on VSCode extension example

### DIFF
--- a/vscode-extensions/setup.sh
+++ b/vscode-extensions/setup.sh
@@ -1,5 +1,5 @@
 #!/bin/bash
 echo 'debconf debconf/frontend select Noninteractive' | sudo debconf-set-selections
-cd /tmp && apt install bsdtar -y
+cd /tmp && apt update && apt install bsdtar -y
 curl -L https://marketplace.visualstudio.com/_apis/public/gallery/publishers/humao/vsextensions/rest-client/0.24.3/vspackage | bsdtar -xvf - extension
 mv extension /opt/.katacodacode/extensions/humao.rest-client-0.24.3

--- a/vscode-extensions/step1.md
+++ b/vscode-extensions/step1.md
@@ -1,7 +1,7 @@
 To install a VSCode extension execute the following in a background script:
 
 ```
-cd /tmp && apt install bsdtar -y
+cd /tmp && apt update && apt install bsdtar -y
 curl -L https://marketplace.visualstudio.com/_apis/public/gallery/publishers/humao/vsextensions/rest-client/0.24.3/vspackage | bsdtar -xvf - extension
 mv extension /opt/.katacodacode/extensions/humao.rest-client-0.24.3
 ```


### PR DESCRIPTION
Adds `apt update` to avoid outdated URL for bsdtar, etc.