### PR TITLE
Add new simplified challenge template

### DIFF
--- a/challenges-pathway.json
+++ b/challenges-pathway.json
@@ -2,6 +2,11 @@
   "title": "Challenges Examples",
   "description": "Examples of how to create Challenges on Katacoda",
   "courses": [{
+      "course_id": "skills-challenge-template",
+      "title": "Skills Challenge Template",
+      "description": "Basic template for a skills challenge"
+    },
+    {
       "course_id": "node-challenge-1",
       "title": "Challenge Example -  Node.js",
       "description": "How to create a challenge on using Node.js"

--- a/challenges/challenge-hello-world/1_hint.sh
+++ b/challenges/challenge-hello-world/1_hint.sh
@@ -1,0 +1,17 @@
+#
+# See hint documentation: https://www.katacoda.community/challenges.html#hints
+#
+
+seconds_sofar=$1
+
+# echo "Debug Hint Task 1: $seconds_sofar"
+
+# This hint message will appear between 10-20 seconds elapsed after the task began
+if [[ $seconds_sofar -ge 10 &&  $seconds_sofar -lt 20 ]]; then
+  echo "Still working on it? I'll show a hint very soon..."
+fi
+
+# This hint message will appear 20+ seconds elapsed after the task began
+if [ $seconds_sofar -ge 20 ]; then
+  echo "**Hint:** Normally, this hint would give help nudge you toward the solution. (As it is, I'm just going to tell you the answer, in case you're new to the command line. The simplest way to create a new file is the command 'touch'. Try typing 'touch bananas.txt' and then hit enter.)"
+fi

--- a/challenges/challenge-hello-world/1_task.md
+++ b/challenges/challenge-hello-world/1_task.md
@@ -1,0 +1,1 @@
+Create a new file called `bananas.txt`.

--- a/challenges/challenge-hello-world/1_verify.sh
+++ b/challenges/challenge-hello-world/1_verify.sh
@@ -1,0 +1,1 @@
+test -f /root/bananas.txt

--- a/challenges/challenge-hello-world/2_hint.sh
+++ b/challenges/challenge-hello-world/2_hint.sh
@@ -1,0 +1,17 @@
+#
+# See hint documentation: https://www.katacoda.community/challenges.html#hints
+#
+
+seconds_sofar=$1
+
+# echo "Debug Hint Task 2: $seconds_sofar"
+
+# This hint message will appear between 10-20 seconds elapsed after the task began
+if [[ $seconds_sofar -ge 10 &&  $seconds_sofar -lt 20 ]]; then
+  echo "Still working on it? I'll show a hint very soon..."
+fi
+
+# This hint message will appear 20+ seconds elapsed after the task began
+if [ $seconds_sofar -ge 20 ]; then
+  echo "**Hint:** This hint could nudge you toward the solution."
+fi

--- a/challenges/challenge-hello-world/2_task.md
+++ b/challenges/challenge-hello-world/2_task.md
@@ -1,0 +1,1 @@
+Now create another file, but this time called `apples.txt`.

--- a/challenges/challenge-hello-world/2_verify.sh
+++ b/challenges/challenge-hello-world/2_verify.sh
@@ -1,0 +1,1 @@
+test -f /root/apples.txt

--- a/challenges/challenge-hello-world/README.md
+++ b/challenges/challenge-hello-world/README.md
@@ -1,0 +1,17 @@
+# Skills Challenge template
+
+Hi! Thanks for opening this README. I am feeling optimistic, as you must be the sort of person who reads the directions before trying to build something new. We are going to get along great.
+
+This folder is a "Hello, world!" example of a skills challenge scenario.
+
+**index.json** --- This is the core definition of any scenario (challenge or not). Note especially:
+
+- the essential `"type": "challenge@0.7"`
+- "imageid": "ubuntu:2004" (this example uses the Ubuntu 20.04 base image, but you should use whatever [base image](https://www.katacoda.community/environments.html) is most appropriate for your challenge)
+
+**SOLUTIONS.md** --- For each task, please provide instructions for the solution. This is NOT shared with the learner, but is for our internal reference, to help test the scenario.
+
+
+_Please reach out with feedback and questions about this example! And thank you for reading the directions._ ♥️
+
+

--- a/challenges/challenge-hello-world/README.md
+++ b/challenges/challenge-hello-world/README.md
@@ -1,16 +1,53 @@
-# Skills Challenge template
+# Skills Challenge Template
 
 Hi! Thanks for opening this README. I am feeling optimistic, as you must be the sort of person who reads the directions before trying to build something new. We are going to get along great.
 
-This folder is a "Hello, world!" example of a skills challenge scenario.
+This folder is a "Hello, world!" example of a skills challenge. Consider this a bare minimum, skeletal starting point, which you will customize to suit your own purposes.
 
-**index.json** --- This is the core definition of any scenario (challenge or not). Note especially:
+Here is a quick lay of the land:
 
-- the essential `"type": "challenge@0.7"`
-- "imageid": "ubuntu:2004" (this example uses the Ubuntu 20.04 base image, but you should use whatever [base image](https://www.katacoda.community/environments.html) is most appropriate for your challenge)
+**index.json** --- This is the core definition of any scenario, challenge or otherwise. Note especially:
 
-**SOLUTIONS.md** --- For each task, please provide instructions for the solution. This is NOT shared with the learner, but is for our internal reference, to help test the scenario.
+- `"type": "challenge@0.7"` --- essential to specify this is a challenge, not a standard scenario
+- `"imageid": "ubuntu:2004"` --- This example uses the Ubuntu 20.04 base image, but you should use whatever [base image](https://www.katacoda.community/environments.html) is most appropriate for your challenge.
+- Note that the `index.json` includes a `verify` and `hint` for each step:
 
+```
+	"steps": [
+	    {
+	        "title": "Task 1: Bananas",
+	        "text": "1_task.md",
+	        "verify": "1_verify.sh",
+	        "hint": "1_hint.sh"
+	    },
+		…
+	]
+```
+
+The `verify` points to a shell script. This is run continuously until a success code (exit code 0) is returned.
+
+The `hint` is another shell script that defines what hints to display for that task/step and when (that is, under what conditions).
+
+**.md files** --- The Markdown files are standard Markdown, just as used for standard scenarios. Not all the Katacoda Markdown extensions can be used in this context, however (such as clickable code shortcuts).
+
+**.sh files** --- Bash shell scripts, as described above.
+
+For clarity, we strongly recommend following the naming convention here in this example, whereby files are prefixed with the related task/step number:
+
+```
+1_hint.sh
+1_task.md
+1_verify.sh
+2_hint.sh
+2_task.md
+2_verify.sh
+```
+
+**finish.md** --- Currently, the finish overlay isn't shown for challenges, so no one will ever see this.
+
+**SOLUTIONS.md** --- For each task, please provide instructions for the solution. This is _not_ shared with the learner, but is for our internal reference, to help with testing.
+
+Please also review the [skills challenge documentation here](https://www.katacoda.community/challenges.html).
 
 _Please reach out with feedback and questions about this example! And thank you for reading the directions._ ♥️
 

--- a/challenges/challenge-hello-world/SOLUTIONS.md
+++ b/challenges/challenge-hello-world/SOLUTIONS.md
@@ -1,0 +1,35 @@
+# SOLUTIONS
+
+For each task, please provide instructions for the solution. This is NOT shared with the learner, but is for our internal reference, to help test the scenario.
+
+## Task 1 Solution
+
+- Poke the widget
+- Change the value
+- Paste in the code
+- Run the thing
+- [etc...]
+
+## Task 2 Solution
+
+- xxxxx
+- xxxxx
+- xxxxx
+
+## Task 3 Solution
+
+- xxxxx
+- xxxxx
+- xxxxx
+
+## Task 4 Solution
+
+- xxxxx
+- xxxxx
+- xxxxx
+
+## Task 5 Solution
+
+- xxxxx
+- xxxxx
+- xxxxx

--- a/challenges/challenge-hello-world/assets/example-asset.txt
+++ b/challenges/challenge-hello-world/assets/example-asset.txt
@@ -1,0 +1,21 @@
+Hi! I'm just an example asset. Don't mind me.
+
+I'm only here because the index.json specified to copy over 
+the contents of the scenario's source /assets/ folder into 
+the environment's /root/ folder, like so:
+
+        "assets": {
+            "client": [
+                { "file": "*", "target": "~/" }
+            ]
+        }
+
+The ~/ just refers to the environment user's home folder. 
+That user is named "root". Once the environment loads, try 
+confirming that this example got copied over with:
+
+	$ pwd
+	/root
+	
+	$ ls
+	example-asset.txt

--- a/challenges/challenge-hello-world/finish.md
+++ b/challenges/challenge-hello-world/finish.md
@@ -1,0 +1,1 @@
+You made it to the end! But the finish page is ignored for challenges, so no one will ever read this.  Boo hoo hoo hoo.

--- a/challenges/challenge-hello-world/index.json
+++ b/challenges/challenge-hello-world/index.json
@@ -1,0 +1,41 @@
+{
+    "type": "challenge@0.7",
+    "title": "Skills Challenge Template",
+    "description": "Basic template for a skills challenge",
+    "difficulty": "Beginner",
+    "time": "5 minutes",
+    "details": {
+        "steps": [
+            {
+                "title": "Task 1 - Bananas",
+                "text": "1_task.md",
+                "verify": "1_verify.sh",
+                "hint": "1_hint.sh"
+            },
+            {
+                "title": "Task 2 - Apples",
+                "text": "2_task.md",
+                "verify": "2_verify.sh",
+                "hint": "2_hint.sh"
+            }
+        ],
+        "intro": {
+            "text": "intro.md"
+        },
+        "finish": {
+            "text": "finish.md"
+        },
+        "assets": {
+            "client": [
+                { "file": "*", "target": "~/" }
+            ]
+        }
+    },
+    "environment": {
+        "uilayout": "editor-terminal",
+        "hideHiddenFiles": true
+    },
+    "backend": {
+        "imageid": "ubuntu:2004"
+    }
+}

--- a/challenges/challenge-hello-world/index.json
+++ b/challenges/challenge-hello-world/index.json
@@ -7,13 +7,13 @@
     "details": {
         "steps": [
             {
-                "title": "Task 1 - Bananas",
+                "title": "Task 1: Bananas",
                 "text": "1_task.md",
                 "verify": "1_verify.sh",
                 "hint": "1_hint.sh"
             },
             {
-                "title": "Task 2 - Apples",
+                "title": "Task 2: Apples",
                 "text": "2_task.md",
                 "verify": "2_verify.sh",
                 "hint": "2_hint.sh"

--- a/challenges/challenge-hello-world/intro.md
+++ b/challenges/challenge-hello-world/intro.md
@@ -1,0 +1,9 @@
+# Skills Challenge Template
+
+This is a simplified "Hello, world" example for a skills challenge. It uses the challenge format v0.7, and illustrates how to define:
+
+- tasks
+- verification tests
+- hints
+
+Please reference the [detailed challenge documentation here](https://www.katacoda.community/challenges.html).


### PR DESCRIPTION
I've been hosting this simplified challenge example in my personal repo and sharing it with authors:

https://github.com/scotthmurray/katacoda-scenarios

I've now updated it for v0.7, and would like to bring it into the official repo.  I'm also working on updating the challenge authoring docs, and will link to here.

Thanks!