### PR TITLE
Remove outdated/misleading absolute ref recommendation

### DIFF
--- a/displaying-images/step1.md
+++ b/displaying-images/step1.md
@@ -7,5 +7,3 @@ In this scenario, within the Assets directory, a `logo-text-with-head.png` file 
 </pre>
 
 ![Katacoda Logo](./assets/logo-text-with-head.png)
-
-While relative paths may work, for most browsers we recommend using the absolute path.


### PR DESCRIPTION
This line in the example scenario regarding displaying asset images is misleading and prone to confusion. It is difficult for the author to know just what the absolute URL of a scenario asset image would be and probably best to just recommend they use relative asset references consistently. If it does not work, that would be a bug within Katacoda.