### PR TITLE
Updated dead links at create-scenario-101

### DIFF
--- a/create-scenario-101/step1.md
+++ b/create-scenario-101/step1.md
@@ -14,4 +14,4 @@ An example of the current step is `katacoda-scenario-examples/create-scenario-10
 
 All the steps are collected via a JSON file, for example, `katacoda-scenario-examples/create-scenario-101/index.json`{{open}}.
 
-The JSON file defines the scenario title, the description, steps order, the UI layout and environment. You can find more about the layouts within our scenarios at [katacoda.com/docs/scenarios/layouts](https://katacoda.com/docs/scenarios/layouts) and environments at [katacoda.com/docs/scenarios/environments](https://katacoda.com/docs/scenarios/environments).
+The JSON file defines the scenario title, the description, steps order, the UI layout and environment. You can find more about the layouts within our scenarios at [Supported Layouts](https://www.katacoda.community/essentials/layouts.html) and environments at [Supported Environments](https://www.katacoda.community/essentials/environments.html).

--- a/create-scenario-101/step3.md
+++ b/create-scenario-101/step3.md
@@ -20,8 +20,8 @@ For example, to create a new scenario you would run the command `katacoda scenar
 - **Difficulty level:** provide users with a sense of the depth of content, displayed on the intro screen
 - **Estimated time:** provide users with an estimated time to complete, displayed on the intro screen
 - **Number of steps:** the numbers of the steps that the scenario will contain. The CLI will create all the template files for all the steps that you specified
-- **Image:** it will determine which base software will be available for your scenario. For example, if you need docker, java, go, etc as a pre-requisite. For more information read [katacoda.com/docs/scenarios/environments](https://katacoda.com/docs/scenarios/environments)
-- **Layout:** it will determine the disposition of the elements of your scenario. For example, if you want to present only a terminal, or editor + terminal, etc. For more information read [katacoda.com/docs/scenarios/layouts](https://katacoda.com/docs/scenarios/layouts)
+- **Image:** it will determine which base software will be available for your scenario. For example, if you need docker, java, go, etc as a pre-requisite. For more information read [Supported Environments](https://www.katacoda.community/essentials/environments.html)
+- **Layout:** it will determine the disposition of the elements of your scenario. For example, if you want to present only a terminal, or editor + terminal, etc. For more information read [Supported Layouts](https://www.katacoda.community/essentials/layouts.html)
 
 With this information, the CLI will create a folder with the name of the ***friendly URL*** introduced and will create inside of that folder the required files for your scenario.
 

--- a/create-scenario-101/step5.md
+++ b/create-scenario-101/step5.md
@@ -1,5 +1,5 @@
 As changes are being made to the content, when they are pushed into the master branch of a Git repository, the content on Katacoda can automatically be updated via a webhook.
 
-To configure the Webhook, follow the guide at [katacoda.com/docs/configure-git](https://katacoda.com/docs/configure-git).
+To configure the Webhook, follow the guide at [Create Author Profile](https://www.katacoda.community/essentials/author-profile.html).
 
 Once the webhook is installed, everytime you make a push to update to your content, Katacoda will be automatically updated.


### PR DESCRIPTION
Hi 😃

I found dead links in markdown files when I'm trying scenario. And I updated.

- [Creating Your First Katacoda Scenario | scenario-examples | Katacoda](https://katacoda.com/scenario-examples/scenarios/create-scenario-101)
    - `create-scenario-101/step1.md`
    - `create-scenario-101/step3.md`
    - `create-scenario-101/step5.md`

Could you review it?

Thanks.