### PR TITLE
Updated deprecated imageid at quiz

### DIFF
--- a/quiz/index.json
+++ b/quiz/index.json
@@ -22,6 +22,6 @@
         "uilayout": "terminal"
     },
     "backend": {
-        "imageid": "ubuntu"
+        "imageid": "ubuntu:2004"
     }
 }


### PR DESCRIPTION
Hi 😃

I found deprecated imageid at `quiz/index.json` when I'm trying `Creating a Katacoda Course` scenario.

It depends on `Quiz` scenario at Step 4.

- https://katacoda.com/scenario-examples/scenarios/create-course

![image](https://user-images.githubusercontent.com/1573290/149741776-e4c345e1-3aad-41e6-b2ff-3b60f3a0b16d.png)

I updated imageid to latest `ubuntu:2004`. See https://www.katacoda.community/essentials/environments.html
`ubuntu` is already deprecated.

Could you review it?

Thanks.